### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/autogen/docker-compose.yml
+++ b/autogen/docker-compose.yml
@@ -31,7 +31,7 @@ networks:
 
 
 # requirements.txt
-pyautogen>=0.2.0
+ag2>=0.2.0
 qdrant-client>=1.6.0
 python-dotenv>=0.19.0
 fastapi>=0.68.0


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to use a new package name in the application’s configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->